### PR TITLE
Wire DAD payment launch flow

### DIFF
--- a/carrd/dad-payment-embed.html
+++ b/carrd/dad-payment-embed.html
@@ -1,0 +1,283 @@
+<!-- DAD PAYMENT EMBED | Carrd-ready -->
+<div id="dad-payment-embed">
+  <style>
+    #dad-payment-embed {
+      --dad-bg: #061a14;
+      --dad-panel: rgba(255,255,255,.10);
+      --dad-panel-strong: rgba(255,255,255,.16);
+      --dad-text: #f6fff9;
+      --dad-accent: #bbffd0;
+      --dad-line: rgba(255,255,255,.22);
+      width: 100%;
+      min-height: 100svh;
+      display: grid;
+      place-items: center;
+      color: var(--dad-text);
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at 25% 10%, rgba(112,255,174,.32), transparent 30rem),
+        radial-gradient(circle at 80% 70%, rgba(51,174,255,.18), transparent 28rem),
+        linear-gradient(145deg, #04120e, #0b2e22 55%, #04120e);
+      padding: 24px 0;
+      box-sizing: border-box;
+    }
+    #dad-payment-embed * { box-sizing: border-box; }
+    #dad-payment-embed .dad-card {
+      width: min(95vw, 760px);
+      border: 1px solid var(--dad-line);
+      border-radius: 30px;
+      background: var(--dad-panel);
+      box-shadow: 0 20px 90px rgba(0,0,0,.32);
+      backdrop-filter: blur(18px);
+      padding: clamp(22px, 5vw, 48px);
+    }
+    #dad-payment-embed .dad-kicker {
+      margin: 0 0 10px;
+      color: var(--dad-accent);
+      letter-spacing: .22em;
+      font-weight: 800;
+    }
+    #dad-payment-embed h1 {
+      margin: 0 0 24px;
+      font-size: clamp(2.2rem, 7vw, 5rem);
+      line-height: .95;
+      letter-spacing: -.06em;
+    }
+    #dad-payment-embed h2,
+    #dad-payment-embed p { margin-top: 0; }
+    #dad-payment-embed .dad-options,
+    #dad-payment-embed .dad-methods {
+      display: grid;
+      gap: 12px;
+    }
+    #dad-payment-embed button,
+    #dad-payment-embed .dad-custom-row {
+      width: 100%;
+      border: 1px solid var(--dad-line);
+      border-radius: 20px;
+      background: var(--dad-panel-strong);
+      color: var(--dad-text);
+      min-height: 60px;
+      font-size: 1.25rem;
+      font-weight: 850;
+    }
+    #dad-payment-embed button { cursor: pointer; }
+    #dad-payment-embed .dad-custom-row {
+      display: grid;
+      grid-template-columns: 1fr 160px;
+      align-items: center;
+      padding: 0 16px;
+      gap: 12px;
+    }
+    #dad-payment-embed input {
+      width: 100%;
+      border: 1px solid var(--dad-line);
+      border-radius: 14px;
+      background: rgba(0,0,0,.2);
+      color: var(--dad-text);
+      min-height: 46px;
+      padding: 0 12px;
+      font-size: 1.2rem;
+      font-weight: 800;
+    }
+    #dad-payment-embed .dad-summary,
+    #dad-payment-embed .dad-transfer,
+    #dad-payment-embed .dad-notice {
+      margin-top: 18px;
+      border: 1px solid var(--dad-line);
+      border-radius: 22px;
+      background: rgba(255,255,255,.08);
+      padding: 20px;
+    }
+    #dad-payment-embed .dad-summary-label {
+      color: var(--dad-accent);
+      font-weight: 850;
+      letter-spacing: .16em;
+    }
+    #dad-payment-embed .dad-amount {
+      font-size: clamp(2.4rem, 7vw, 4.8rem);
+      line-height: 1;
+      color: var(--dad-text);
+      font-weight: 900;
+      letter-spacing: -.06em;
+    }
+    #dad-payment-embed .dad-methods { margin-top: 18px; }
+    #dad-payment-embed .dad-method:disabled {
+      opacity: .38;
+      cursor: default;
+    }
+    #dad-payment-embed .dad-method.is-active {
+      background: var(--dad-accent);
+      color: #04120e;
+    }
+    #dad-payment-embed .dad-change {
+      margin-top: 12px;
+      background: transparent;
+      min-height: 46px;
+      color: var(--dad-accent);
+    }
+    #dad-payment-embed .dad-notice { color: var(--dad-accent); }
+    #dad-payment-embed .is-hidden { display: none !important; }
+    @media (max-width: 520px) {
+      #dad-payment-embed .dad-custom-row { grid-template-columns: 1fr; padding: 14px; }
+    }
+  </style>
+
+  <section class="dad-card">
+    <p class="dad-kicker">DOLLAR A DAY</p>
+    <h1>CONTRIBUTION: $/DAY</h1>
+
+    <div id="dadOptions" class="dad-options" aria-label="Contribution options">
+      <button type="button" class="dad-option" data-amount="1">$1/day</button>
+      <button type="button" class="dad-option" data-amount="365">$365/year</button>
+      <label class="dad-custom-row" for="dadAmount">
+        <span>Custom Amount</span>
+        <input id="dadAmount" type="number" min="1" step="1" inputmode="decimal" placeholder="$" autocomplete="off" />
+      </label>
+    </div>
+
+    <section id="dadSummary" class="dad-summary is-hidden" aria-live="polite">
+      <p class="dad-summary-label">CONTRIBUTION</p>
+      <p id="contributionAmount" class="dad-amount">$0.00</p>
+      <p id="daysCovered">DAYS COVERED: 0</p>
+      <p id="nextPaymentDate">NEXT PAYMENT DATE: —</p>
+      <button type="button" id="resetContribution" class="dad-change">Change amount</button>
+    </section>
+
+    <section class="dad-methods" aria-label="Payment methods">
+      <button type="button" id="payCard" class="dad-method" disabled>PAY BY CARD</button>
+      <button type="button" id="payEtransfer" class="dad-method" disabled>E-TRANSFER</button>
+      <button type="button" id="payQR" class="dad-method" disabled>QR CODE</button>
+    </section>
+
+    <section id="transferInstructions" class="dad-transfer is-hidden" aria-live="polite">
+      <h2>E-TRANSFER</h2>
+      <p>Send to: <strong>ajfisherco@gmail.com</strong></p>
+      <p id="transferAmount">Amount: —</p>
+      <p>Message: DAD Contribution</p>
+    </section>
+
+    <section id="launchNotice" class="dad-notice is-hidden" aria-live="polite">
+      <p id="launchNoticeText"></p>
+    </section>
+  </section>
+
+  <script>
+    (() => {
+      const SQUARE_CARD_URL = "https://square.link/u/EcyDVlU3?src=sheet";
+      const SQUARE_QR_URL = "https://square.link/u/EcyDVlU3?src=qr";
+      const INTERAC_EMAIL = "ajfisherco@gmail.com";
+
+      const root = document.querySelector("#dad-payment-embed");
+      const options = root.querySelector("#dadOptions");
+      const summary = root.querySelector("#dadSummary");
+      const customAmount = root.querySelector("#dadAmount");
+      const contributionAmount = root.querySelector("#contributionAmount");
+      const daysCovered = root.querySelector("#daysCovered");
+      const nextPaymentDate = root.querySelector("#nextPaymentDate");
+      const resetContribution = root.querySelector("#resetContribution");
+      const payCard = root.querySelector("#payCard");
+      const payEtransfer = root.querySelector("#payEtransfer");
+      const payQR = root.querySelector("#payQR");
+      const transferInstructions = root.querySelector("#transferInstructions");
+      const transferAmount = root.querySelector("#transferAmount");
+      const launchNotice = root.querySelector("#launchNotice");
+      const launchNoticeText = root.querySelector("#launchNoticeText");
+      let selectedAmount = 0;
+
+      function formatCurrency(amount) {
+        return amount.toLocaleString("en-CA", { style: "currency", currency: "CAD", minimumFractionDigits: 2 });
+      }
+
+      function calculateNextDate(days) {
+        const nextDate = new Date();
+        nextDate.setDate(nextDate.getDate() + Math.max(days, 1));
+        return nextDate.toLocaleDateString("en-CA", { month: "long", day: "numeric", year: "numeric" });
+      }
+
+      function buildPaymentUrl(baseUrl, amount) {
+        const url = new URL(baseUrl);
+        url.searchParams.set("amount", amount.toString());
+        return url.toString();
+      }
+
+      function showNotice(message) {
+        launchNoticeText.textContent = message;
+        launchNotice.classList.remove("is-hidden");
+      }
+
+      function hideNotice() {
+        launchNotice.classList.add("is-hidden");
+        launchNoticeText.textContent = "";
+      }
+
+      function setPaymentButtons(active) {
+        [payCard, payEtransfer, payQR].forEach((button) => {
+          button.disabled = !active;
+          button.classList.toggle("is-active", active);
+        });
+      }
+
+      function setAmount(amount) {
+        const nextAmount = Number(amount);
+        if (!Number.isFinite(nextAmount) || nextAmount <= 0) return;
+        selectedAmount = Math.round(nextAmount * 100) / 100;
+        const days = Math.floor(selectedAmount);
+        contributionAmount.textContent = formatCurrency(selectedAmount);
+        daysCovered.textContent = `DAYS COVERED: ${days}`;
+        nextPaymentDate.textContent = `NEXT PAYMENT DATE: ${calculateNextDate(days)}`;
+        transferAmount.textContent = `Amount: ${formatCurrency(selectedAmount)}`;
+        options.classList.add("is-hidden");
+        summary.classList.remove("is-hidden");
+        transferInstructions.classList.add("is-hidden");
+        hideNotice();
+        setPaymentButtons(true);
+      }
+
+      function resetAmount() {
+        selectedAmount = 0;
+        customAmount.value = "";
+        options.classList.remove("is-hidden");
+        summary.classList.add("is-hidden");
+        transferInstructions.classList.add("is-hidden");
+        hideNotice();
+        setPaymentButtons(false);
+      }
+
+      options.addEventListener("click", (event) => {
+        const button = event.target.closest("[data-amount]");
+        if (button) setAmount(button.dataset.amount);
+      });
+
+      customAmount.addEventListener("input", () => {
+        if (Number(customAmount.value) > 0) setAmount(customAmount.value);
+      });
+
+      customAmount.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") setAmount(customAmount.value);
+      });
+
+      resetContribution.addEventListener("click", resetAmount);
+
+      payCard.addEventListener("click", () => {
+        if (!selectedAmount) return;
+        window.open(buildPaymentUrl(SQUARE_CARD_URL, selectedAmount), "_blank", "noopener,noreferrer");
+      });
+
+      payEtransfer.addEventListener("click", async () => {
+        if (!selectedAmount) return;
+        transferInstructions.classList.remove("is-hidden");
+        showNotice("E-transfer instructions copied where supported.");
+        const message = `DAD Contribution ${formatCurrency(selectedAmount)} to ${INTERAC_EMAIL}`;
+        try { await navigator.clipboard.writeText(message); } catch (error) { console.warn("Clipboard copy unavailable", error); }
+      });
+
+      payQR.addEventListener("click", () => {
+        if (!selectedAmount) return;
+        window.open(buildPaymentUrl(SQUARE_QR_URL, selectedAmount), "_blank", "noopener,noreferrer");
+      });
+
+      setPaymentButtons(false);
+    })();
+  </script>
+</div>

--- a/site/dad-payment.css
+++ b/site/dad-payment.css
@@ -105,7 +105,7 @@ h1 {
 
 .summary,
 .instructions,
-.thanks {
+.notice {
   margin-top: 18px;
   border: 1px solid var(--line);
   border-radius: 22px;
@@ -145,6 +145,10 @@ h1 {
   margin-top: 12px;
   background: transparent;
   min-height: 46px;
+  color: var(--accent);
+}
+
+.notice {
   color: var(--accent);
 }
 

--- a/site/dad-payment.css
+++ b/site/dad-payment.css
@@ -1,0 +1,155 @@
+:root {
+  color-scheme: dark;
+  --bg: #061a14;
+  --panel: rgba(255, 255, 255, .1);
+  --panel-strong: rgba(255, 255, 255, .16);
+  --text: #f6fff9;
+  --muted: #b8d8c5;
+  --accent: #bbffd0;
+  --line: rgba(255, 255, 255, .2);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100svh;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 25% 10%, rgba(112, 255, 174, .32), transparent 30rem),
+    radial-gradient(circle at 80% 70%, rgba(51, 174, 255, .18), transparent 28rem),
+    linear-gradient(145deg, #04120e, #0b2e22 55%, #04120e);
+}
+
+.payment-shell {
+  width: min(95vw, 760px);
+  margin: 0 auto;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  padding: 24px 0;
+}
+
+.payment-card {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--panel);
+  box-shadow: 0 20px 90px rgba(0, 0, 0, .32);
+  backdrop-filter: blur(18px);
+  padding: clamp(22px, 5vw, 48px);
+}
+
+.kicker {
+  margin: 0 0 10px;
+  color: var(--accent);
+  letter-spacing: .22em;
+  font-weight: 800;
+}
+
+h1, h2, p { margin-top: 0; }
+
+h1 {
+  font-size: clamp(2.2rem, 7vw, 5rem);
+  line-height: .95;
+  letter-spacing: -.06em;
+  margin-bottom: 24px;
+}
+
+.option-list,
+.payment-methods {
+  display: grid;
+  gap: 12px;
+}
+
+.option-button,
+.method-button,
+.text-button,
+.custom-row {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: var(--panel-strong);
+  color: var(--text);
+  min-height: 60px;
+  font-size: 1.25rem;
+  font-weight: 850;
+}
+
+.option-button,
+.method-button,
+.text-button {
+  cursor: pointer;
+}
+
+.custom-row {
+  display: grid;
+  grid-template-columns: 1fr 160px;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+}
+
+.custom-row input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(0, 0, 0, .2);
+  color: var(--text);
+  min-height: 46px;
+  padding: 0 12px;
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.summary,
+.instructions,
+.thanks {
+  margin-top: 18px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, .08);
+  padding: 20px;
+}
+
+.summary-label {
+  color: var(--accent);
+  font-weight: 850;
+  letter-spacing: .16em;
+}
+
+.amount {
+  font-size: clamp(2.4rem, 7vw, 4.8rem);
+  line-height: 1;
+  color: var(--text);
+  font-weight: 900;
+  letter-spacing: -.06em;
+}
+
+.payment-methods {
+  margin-top: 18px;
+}
+
+.method-button:disabled {
+  opacity: .38;
+  cursor: default;
+}
+
+.method-button.is-active {
+  background: var(--accent);
+  color: #04120e;
+}
+
+.text-button {
+  margin-top: 12px;
+  background: transparent;
+  min-height: 46px;
+  color: var(--accent);
+}
+
+.is-hidden { display: none; }
+
+@media (max-width: 520px) {
+  .custom-row { grid-template-columns: 1fr; padding: 14px; }
+}

--- a/site/dad-payment.html
+++ b/site/dad-payment.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DAD Payment | Dollar A Day</title>
+  <meta name="description" content="Dollar A Day contribution flow." />
+  <link rel="stylesheet" href="./dad-payment.css" />
+</head>
+<body>
+  <main class="payment-shell">
+    <section class="payment-card">
+      <p class="kicker">DOLLAR A DAY</p>
+      <h1>CONTRIBUTION: $/DAY</h1>
+
+      <div id="dadOptions" class="option-list" aria-label="Contribution options">
+        <button type="button" class="option-button" data-amount="1">$1/day</button>
+        <button type="button" class="option-button" data-amount="365">$365/year</button>
+        <label class="custom-row" for="dadAmount">
+          <span>Custom Amount</span>
+          <input id="dadAmount" type="number" min="1" step="1" inputmode="decimal" placeholder="$" />
+        </label>
+      </div>
+
+      <section id="dadSummary" class="summary is-hidden" aria-live="polite">
+        <p class="summary-label">CONTRIBUTION</p>
+        <p id="contributionAmount" class="amount">$0.00</p>
+        <p id="daysCovered">DAYS COVERED: 0</p>
+        <p id="nextPaymentDate">NEXT PAYMENT DATE: —</p>
+        <button type="button" id="resetContribution" class="text-button">Change amount</button>
+      </section>
+
+      <section class="payment-methods" aria-label="Payment methods">
+        <button type="button" id="payCard" class="method-button" disabled>PAY BY CARD</button>
+        <button type="button" id="payEtransfer" class="method-button" disabled>E-TRANSFER</button>
+        <button type="button" id="payQR" class="method-button" disabled>QR CODE</button>
+      </section>
+
+      <section id="transferInstructions" class="instructions is-hidden" aria-live="polite">
+        <h2>E-TRANSFER</h2>
+        <p>Send to: <strong>ajfisherco@gmail.com</strong></p>
+        <p id="transferAmount">Amount: —</p>
+        <p>Message: DAD Contribution</p>
+      </section>
+
+      <section id="thankYou" class="thanks is-hidden" aria-live="polite">
+        <h2>Thank you for supporting Dollar A Day.</h2>
+        <p id="thanksAmount">Contribution selected.</p>
+        <p>Confirmation and receipt handling follow payment activity.</p>
+      </section>
+    </section>
+  </main>
+
+  <script src="./dad-payment.js"></script>
+</body>
+</html>

--- a/site/dad-payment.html
+++ b/site/dad-payment.html
@@ -18,7 +18,7 @@
         <button type="button" class="option-button" data-amount="365">$365/year</button>
         <label class="custom-row" for="dadAmount">
           <span>Custom Amount</span>
-          <input id="dadAmount" type="number" min="1" step="1" inputmode="decimal" placeholder="$" />
+          <input id="dadAmount" type="number" min="1" step="1" inputmode="decimal" placeholder="$" autocomplete="off" />
         </label>
       </div>
 
@@ -43,10 +43,8 @@
         <p>Message: DAD Contribution</p>
       </section>
 
-      <section id="thankYou" class="thanks is-hidden" aria-live="polite">
-        <h2>Thank you for supporting Dollar A Day.</h2>
-        <p id="thanksAmount">Contribution selected.</p>
-        <p>Confirmation and receipt handling follow payment activity.</p>
+      <section id="launchNotice" class="notice is-hidden" aria-live="polite">
+        <p id="launchNoticeText"></p>
       </section>
     </section>
   </main>

--- a/site/dad-payment.js
+++ b/site/dad-payment.js
@@ -14,8 +14,8 @@ const payEtransfer = document.querySelector("#payEtransfer");
 const payQR = document.querySelector("#payQR");
 const transferInstructions = document.querySelector("#transferInstructions");
 const transferAmount = document.querySelector("#transferAmount");
-const thankYou = document.querySelector("#thankYou");
-const thanksAmount = document.querySelector("#thanksAmount");
+const launchNotice = document.querySelector("#launchNotice");
+const launchNoticeText = document.querySelector("#launchNoticeText");
 
 let selectedAmount = 0;
 
@@ -37,6 +37,26 @@ function calculateNextDate(days) {
   });
 }
 
+function hasLiveUrl(url) {
+  return Boolean(url && !url.includes("PASTE_") && /^https?:\/\//i.test(url));
+}
+
+function buildPaymentUrl(baseUrl, amount) {
+  const url = new URL(baseUrl);
+  url.searchParams.set("amount", amount.toString());
+  return url.toString();
+}
+
+function showNotice(message) {
+  launchNoticeText.textContent = message;
+  launchNotice.classList.remove("is-hidden");
+}
+
+function hideNotice() {
+  launchNotice.classList.add("is-hidden");
+  launchNoticeText.textContent = "";
+}
+
 function setPaymentButtons(active) {
   [payCard, payEtransfer, payQR].forEach((button) => {
     button.disabled = !active;
@@ -45,9 +65,9 @@ function setPaymentButtons(active) {
 }
 
 function setAmount(amount) {
-  selectedAmount = Number(amount);
+  const nextAmount = Number(amount);
 
-  if (!selectedAmount || selectedAmount <= 0) {
+  if (!Number.isFinite(nextAmount) || nextAmount <= 0) {
     selectedAmount = 0;
     contributionAmount.textContent = "$0.00";
     daysCovered.textContent = "DAYS COVERED: 0";
@@ -56,15 +76,18 @@ function setAmount(amount) {
     return;
   }
 
+  selectedAmount = Math.round(nextAmount * 100) / 100;
   const days = Math.floor(selectedAmount);
+
   contributionAmount.textContent = formatCurrency(selectedAmount);
   daysCovered.textContent = `DAYS COVERED: ${days}`;
   nextPaymentDate.textContent = `NEXT PAYMENT DATE: ${calculateNextDate(days)}`;
   transferAmount.textContent = `Amount: ${formatCurrency(selectedAmount)}`;
-  thanksAmount.textContent = `Contribution: ${formatCurrency(selectedAmount)}`;
 
   options.classList.add("is-hidden");
   summary.classList.remove("is-hidden");
+  transferInstructions.classList.add("is-hidden");
+  hideNotice();
   setPaymentButtons(true);
 }
 
@@ -74,7 +97,7 @@ function resetAmount() {
   options.classList.remove("is-hidden");
   summary.classList.add("is-hidden");
   transferInstructions.classList.add("is-hidden");
-  thankYou.classList.add("is-hidden");
+  hideNotice();
   setPaymentButtons(false);
 }
 
@@ -84,7 +107,10 @@ options.addEventListener("click", (event) => {
   setAmount(button.dataset.amount);
 });
 
-customAmount.addEventListener("change", () => setAmount(customAmount.value));
+customAmount.addEventListener("input", () => {
+  if (Number(customAmount.value) > 0) setAmount(customAmount.value);
+});
+
 customAmount.addEventListener("keydown", (event) => {
   if (event.key === "Enter") setAmount(customAmount.value);
 });
@@ -93,14 +119,20 @@ resetContribution.addEventListener("click", resetAmount);
 
 payCard.addEventListener("click", () => {
   if (!selectedAmount) return;
-  const url = `${SQUARE_CARD_URL}?amount=${encodeURIComponent(selectedAmount)}`;
-  window.open(url, "_blank", "noopener,noreferrer");
-  thankYou.classList.remove("is-hidden");
+
+  if (!hasLiveUrl(SQUARE_CARD_URL)) {
+    showNotice("Square card link required before launch.");
+    return;
+  }
+
+  window.open(buildPaymentUrl(SQUARE_CARD_URL, selectedAmount), "_blank", "noopener,noreferrer");
 });
 
 payEtransfer.addEventListener("click", async () => {
   if (!selectedAmount) return;
+
   transferInstructions.classList.remove("is-hidden");
+  showNotice("E-transfer instructions copied where supported.");
 
   const message = `DAD Contribution ${formatCurrency(selectedAmount)} to ${INTERAC_EMAIL}`;
   try {
@@ -112,9 +144,13 @@ payEtransfer.addEventListener("click", async () => {
 
 payQR.addEventListener("click", () => {
   if (!selectedAmount) return;
-  const url = `${SQUARE_QR_URL}?amount=${encodeURIComponent(selectedAmount)}`;
-  window.open(url, "_blank", "noopener,noreferrer");
-  thankYou.classList.remove("is-hidden");
+
+  if (!hasLiveUrl(SQUARE_QR_URL)) {
+    showNotice("Square QR link required before launch.");
+    return;
+  }
+
+  window.open(buildPaymentUrl(SQUARE_QR_URL, selectedAmount), "_blank", "noopener,noreferrer");
 });
 
 setPaymentButtons(false);

--- a/site/dad-payment.js
+++ b/site/dad-payment.js
@@ -1,5 +1,5 @@
-const SQUARE_CARD_URL = "PASTE_SQUARE_CARD_LINK_HERE";
-const SQUARE_QR_URL = "PASTE_SQUARE_QR_LINK_HERE";
+const SQUARE_CARD_URL = "https://square.link/u/EcyDVlU3?src=sheet";
+const SQUARE_QR_URL = "https://square.link/u/EcyDVlU3?src=qr";
 const INTERAC_EMAIL = "ajfisherco@gmail.com";
 
 const options = document.querySelector("#dadOptions");

--- a/site/dad-payment.js
+++ b/site/dad-payment.js
@@ -1,0 +1,120 @@
+const SQUARE_CARD_URL = "PASTE_SQUARE_CARD_LINK_HERE";
+const SQUARE_QR_URL = "PASTE_SQUARE_QR_LINK_HERE";
+const INTERAC_EMAIL = "ajfisherco@gmail.com";
+
+const options = document.querySelector("#dadOptions");
+const summary = document.querySelector("#dadSummary");
+const customAmount = document.querySelector("#dadAmount");
+const contributionAmount = document.querySelector("#contributionAmount");
+const daysCovered = document.querySelector("#daysCovered");
+const nextPaymentDate = document.querySelector("#nextPaymentDate");
+const resetContribution = document.querySelector("#resetContribution");
+const payCard = document.querySelector("#payCard");
+const payEtransfer = document.querySelector("#payEtransfer");
+const payQR = document.querySelector("#payQR");
+const transferInstructions = document.querySelector("#transferInstructions");
+const transferAmount = document.querySelector("#transferAmount");
+const thankYou = document.querySelector("#thankYou");
+const thanksAmount = document.querySelector("#thanksAmount");
+
+let selectedAmount = 0;
+
+function formatCurrency(amount) {
+  return amount.toLocaleString("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    minimumFractionDigits: 2
+  });
+}
+
+function calculateNextDate(days) {
+  const nextDate = new Date();
+  nextDate.setDate(nextDate.getDate() + Math.max(days, 1));
+  return nextDate.toLocaleDateString("en-CA", {
+    month: "long",
+    day: "numeric",
+    year: "numeric"
+  });
+}
+
+function setPaymentButtons(active) {
+  [payCard, payEtransfer, payQR].forEach((button) => {
+    button.disabled = !active;
+    button.classList.toggle("is-active", active);
+  });
+}
+
+function setAmount(amount) {
+  selectedAmount = Number(amount);
+
+  if (!selectedAmount || selectedAmount <= 0) {
+    selectedAmount = 0;
+    contributionAmount.textContent = "$0.00";
+    daysCovered.textContent = "DAYS COVERED: 0";
+    nextPaymentDate.textContent = "NEXT PAYMENT DATE: —";
+    setPaymentButtons(false);
+    return;
+  }
+
+  const days = Math.floor(selectedAmount);
+  contributionAmount.textContent = formatCurrency(selectedAmount);
+  daysCovered.textContent = `DAYS COVERED: ${days}`;
+  nextPaymentDate.textContent = `NEXT PAYMENT DATE: ${calculateNextDate(days)}`;
+  transferAmount.textContent = `Amount: ${formatCurrency(selectedAmount)}`;
+  thanksAmount.textContent = `Contribution: ${formatCurrency(selectedAmount)}`;
+
+  options.classList.add("is-hidden");
+  summary.classList.remove("is-hidden");
+  setPaymentButtons(true);
+}
+
+function resetAmount() {
+  selectedAmount = 0;
+  customAmount.value = "";
+  options.classList.remove("is-hidden");
+  summary.classList.add("is-hidden");
+  transferInstructions.classList.add("is-hidden");
+  thankYou.classList.add("is-hidden");
+  setPaymentButtons(false);
+}
+
+options.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-amount]");
+  if (!button) return;
+  setAmount(button.dataset.amount);
+});
+
+customAmount.addEventListener("change", () => setAmount(customAmount.value));
+customAmount.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") setAmount(customAmount.value);
+});
+
+resetContribution.addEventListener("click", resetAmount);
+
+payCard.addEventListener("click", () => {
+  if (!selectedAmount) return;
+  const url = `${SQUARE_CARD_URL}?amount=${encodeURIComponent(selectedAmount)}`;
+  window.open(url, "_blank", "noopener,noreferrer");
+  thankYou.classList.remove("is-hidden");
+});
+
+payEtransfer.addEventListener("click", async () => {
+  if (!selectedAmount) return;
+  transferInstructions.classList.remove("is-hidden");
+
+  const message = `DAD Contribution ${formatCurrency(selectedAmount)} to ${INTERAC_EMAIL}`;
+  try {
+    await navigator.clipboard.writeText(message);
+  } catch (error) {
+    console.warn("Clipboard copy unavailable", error);
+  }
+});
+
+payQR.addEventListener("click", () => {
+  if (!selectedAmount) return;
+  const url = `${SQUARE_QR_URL}?amount=${encodeURIComponent(selectedAmount)}`;
+  window.open(url, "_blank", "noopener,noreferrer");
+  thankYou.classList.remove("is-hidden");
+});
+
+setPaymentButtons(false);

--- a/webnames-export/README-DEPLOY-WEBNAMES.md
+++ b/webnames-export/README-DEPLOY-WEBNAMES.md
@@ -1,0 +1,45 @@
+# Webnames Export Deployment
+
+This folder contains the launch-ready static export for Webnames/Plesk.
+
+## File to deploy
+
+Upload this file:
+
+- `webnames-export/ipmdb/index.html`
+
+## Target location in Webnames File Manager
+
+Upload it to:
+
+- `httpdocs/ipmdb/index.html`
+
+If the `ipmdb` folder already exists, open it and replace only `index.html`.
+
+## Live URL after upload
+
+Open:
+
+- `https://ajfisherco.com/ipmdb/`
+
+## What this page includes
+
+- One mobile-first IPMdb / DAD switcher.
+- IPMdb idea intake.
+- DAD payment flow.
+- Square card link: `https://square.link/u/EcyDVlU3?src=site`
+- Square QR link: `https://square.link/u/EcyDVlU3?src=qr`
+- Interac email: `ajfisherco@gmail.com`
+
+## Launch test
+
+1. Open `https://ajfisherco.com/ipmdb/`.
+2. Test IPMdb form.
+3. Tap DAD.
+4. Select `$1/day`.
+5. Confirm payment buttons activate.
+6. Tap Pay by Card and verify Square opens.
+7. Tap QR and verify Square opens.
+8. Tap E-Transfer and verify instructions display.
+
+If all pass, this is the launch candidate.

--- a/webnames-export/ipmdb/index.html
+++ b/webnames-export/ipmdb/index.html
@@ -1,0 +1,450 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>IPMdb.ai | DAD</title>
+  <meta name="description" content="IPMdb.ai Ideas to Assets and DAD Dollar A Day launch page." />
+  <style>
+    :root{
+      --white:#f7fbff;
+      --blue:#1e9cff;
+      --blue2:#004fea;
+      --green:#6cff22;
+      --green2:#2fc50f;
+      --ink:#020812;
+      --line:rgba(255,255,255,.24);
+      --glass:rgba(255,255,255,.12);
+      --glass2:rgba(255,255,255,.18);
+    }
+    *{box-sizing:border-box}
+    html{scroll-behavior:smooth}
+    body{
+      margin:0;
+      min-height:100svh;
+      background:#03070b;
+      color:var(--white);
+      font-family:Arial,Helvetica,sans-serif;
+      overflow-x:hidden;
+    }
+    .app{
+      min-height:100svh;
+      width:100%;
+      display:grid;
+      place-items:center;
+      padding:12px;
+      background:
+        radial-gradient(circle at 20% 0%,rgba(26,143,255,.28),transparent 26rem),
+        radial-gradient(circle at 80% 100%,rgba(103,255,38,.24),transparent 28rem),
+        linear-gradient(135deg,#020812,#061b22 58%,#03110a);
+    }
+    .shell{
+      width:min(100%,760px);
+      min-height:calc(100svh - 24px);
+      display:grid;
+      place-items:center;
+    }
+    .panel{
+      width:100%;
+      max-width:560px;
+      min-height:calc(100svh - 30px);
+      border-radius:30px;
+      border:1px solid var(--line);
+      overflow:hidden;
+      box-shadow:0 24px 90px rgba(0,0,0,.42);
+      position:relative;
+    }
+    .panel.ipm{
+      background:
+        radial-gradient(circle at 50% 0%,rgba(80,202,255,.34),transparent 23rem),
+        linear-gradient(180deg,#0b7eb6 0%,#062c55 52%,#03111b 100%);
+    }
+    .panel.dad{
+      background:
+        radial-gradient(circle at 50% 0%,rgba(105,255,33,.28),transparent 24rem),
+        linear-gradient(180deg,#0b563e 0%,#07251d 58%,#020806 100%);
+    }
+    .inner{
+      width:100%;
+      min-height:calc(100svh - 30px);
+      padding:clamp(18px,4vw,34px);
+      display:flex;
+      flex-direction:column;
+      justify-content:flex-start;
+      gap:14px;
+    }
+    .nav{
+      display:flex;
+      justify-content:space-between;
+      gap:10px;
+      align-items:center;
+      margin-bottom:4px;
+    }
+    .pill{
+      min-height:44px;
+      padding:10px 15px;
+      border-radius:999px;
+      border:1px solid rgba(255,255,255,.38);
+      background:linear-gradient(#2f8cff,#0750e7);
+      color:#fff;
+      text-decoration:none;
+      font-weight:900;
+      font-size:clamp(15px,4.2vw,21px);
+      white-space:nowrap;
+      box-shadow:0 0 20px rgba(0,120,255,.38);
+    }
+    .ghost{
+      background:linear-gradient(#55f936,#21a90a);
+      color:#061006;
+    }
+    h1,h2,p{margin:0;text-align:center}
+    .logo-ipm{
+      font-size:clamp(64px,18vw,116px);
+      line-height:.86;
+      font-weight:500;
+      color:#52cfff;
+      text-shadow:0 0 26px rgba(82,207,255,.7);
+      letter-spacing:-.06em;
+      margin-top:8px;
+    }
+    .logo-dad{
+      font-size:clamp(76px,22vw,128px);
+      line-height:.82;
+      color:var(--green);
+      font-weight:900;
+      text-shadow:0 0 30px rgba(108,255,34,.84);
+      margin-top:6px;
+    }
+    .headline{
+      font-size:clamp(30px,8vw,50px);
+      line-height:.95;
+      font-weight:900;
+      letter-spacing:.06em;
+    }
+    .subline{
+      font-size:clamp(20px,5.8vw,35px);
+      line-height:1.05;
+      font-weight:900;
+      margin-top:4px;
+    }
+    .greenline{
+      color:var(--green);
+      text-shadow:0 0 20px rgba(108,255,34,.78);
+    }
+    .form,.choices,.methods{
+      display:grid;
+      gap:12px;
+      width:100%;
+      margin-top:8px;
+    }
+    input,select,textarea,button{
+      font:inherit;
+    }
+    .field, .select, textarea, .choice, .method, .lock, .change{
+      width:100%;
+      border-radius:20px;
+      border:1px solid rgba(255,255,255,.28);
+      background:var(--glass);
+      color:#fff;
+      font-weight:900;
+      min-height:58px;
+      padding:0 18px;
+      outline:none;
+    }
+    .field::placeholder,textarea::placeholder{color:rgba(255,255,255,.72)}
+    .select{appearance:auto;white-space:normal;text-overflow:clip}
+    textarea{
+      min-height:142px;
+      resize:vertical;
+      padding:18px;
+      line-height:1.12;
+    }
+    .field,.select,textarea{
+      font-size:clamp(17px,4.9vw,25px);
+    }
+    .choice,.method,.lock,.change{
+      cursor:pointer;
+      font-size:clamp(21px,6vw,32px);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      text-align:center;
+    }
+    .choice{min-height:60px;background:var(--glass2)}
+    .custom{
+      width:100%;
+      border-radius:20px;
+      border:1px solid rgba(255,255,255,.28);
+      background:var(--glass2);
+      padding:14px;
+      font-weight:900;
+      font-size:clamp(22px,6.4vw,34px);
+      display:grid;
+      gap:10px;
+    }
+    .custom input{
+      width:100%;
+      min-height:54px;
+      border-radius:16px;
+      border:1px solid rgba(255,255,255,.28);
+      background:rgba(0,0,0,.22);
+      color:#fff;
+      font-weight:900;
+      font-size:30px;
+      padding:0 18px;
+    }
+    .lock{
+      min-height:72px;
+      border:0;
+      background:linear-gradient(#29bdff,#006dff);
+      box-shadow:0 0 28px rgba(41,189,255,.5);
+    }
+    .method:disabled{
+      opacity:.34;
+      cursor:default;
+      background:rgba(0,0,0,.2);
+    }
+    .method.active{
+      background:linear-gradient(#83ff37,#36bd15);
+      color:#061006;
+      box-shadow:0 0 26px rgba(90,255,40,.5);
+    }
+    .summary,.transfer,.notice,.receipt{
+      margin-top:8px;
+      padding:15px;
+      border-radius:20px;
+      border:1px solid rgba(120,255,120,.42);
+      background:rgba(0,0,0,.22);
+      font-weight:900;
+      display:grid;
+      gap:8px;
+    }
+    .amount{
+      font-size:clamp(42px,12vw,74px);
+      line-height:1;
+      font-weight:900;
+    }
+    .change{
+      min-height:46px;
+      background:transparent;
+      color:#bbffd0;
+      font-size:18px;
+      margin-top:4px;
+    }
+    .foot{
+      margin-top:auto;
+      font-size:clamp(15px,4.3vw,21px);
+      line-height:1.05;
+      opacity:.95;
+      padding-top:8px;
+    }
+    .hidden{display:none!important}
+    @media(max-height:760px){
+      .inner{gap:10px;padding:14px}
+      .logo-dad{font-size:clamp(62px,18vw,100px)}
+      .logo-ipm{font-size:clamp(56px,15vw,92px)}
+      textarea{min-height:108px}
+      .field,.select,.choice,.method{min-height:52px}
+      .lock{min-height:62px}
+      .headline{font-size:clamp(25px,7vw,42px)}
+      .subline{font-size:clamp(18px,5vw,30px)}
+    }
+  </style>
+</head>
+<body>
+  <main class="app">
+    <div class="shell">
+      <section id="panel" class="panel ipm" aria-live="polite">
+        <div id="ipmView" class="inner">
+          <nav class="nav">
+            <button class="pill ghost" type="button" data-show="dad">← DAD</button>
+            <button class="pill" type="button" data-show="dad">DAD →</button>
+          </nav>
+
+          <h1 class="logo-ipm">IPMdb</h1>
+          <h2 class="headline">IDEAS 2 ASSETS</h2>
+          <p class="subline">THE FUTURE LIVES HERE</p>
+
+          <section class="form">
+            <input id="ideaTitle" class="field" type="text" maxlength="80" placeholder="YOUR IDEA IN ONE WORD" />
+            <input id="ideaEmail" class="field" type="email" placeholder="YOUR EMAIL" />
+            <select id="ideaSource" class="select">
+              <option value="">HOW DID YOU GET HERE?</option>
+              <option>Google Search</option>
+              <option>Friend</option>
+              <option>QR Code</option>
+              <option>Dollar A Day</option>
+              <option>Facebook</option>
+              <option>Truth Social</option>
+              <option>AJF</option>
+              <option>SQ</option>
+              <option>Other</option>
+            </select>
+            <textarea id="ideaDescription" placeholder="Describe your idea..."></textarea>
+            <button id="lockIdea" class="lock" type="button">LOCK IDEA</button>
+          </section>
+
+          <section id="ideaReceipt" class="receipt hidden">
+            <p>Your submission is ready to send.</p>
+            <p id="assetIdLine"></p>
+          </section>
+
+          <p class="foot">Every submission receives a permanent timestamp and Asset ID.</p>
+        </div>
+
+        <div id="dadView" class="inner hidden">
+          <nav class="nav">
+            <button class="pill" type="button" data-show="ipm">← IPMdb.ai</button>
+            <button class="pill ghost" type="button" data-show="ipm">IPMdb.ai →</button>
+          </nav>
+
+          <h1 class="logo-dad">DAD</h1>
+          <h2 class="headline">DOLLAR A DAY</h2>
+          <p class="subline">$1/DAY = 1 GOAL</p>
+          <p class="subline greenline">END HOMELESSNESS</p>
+
+          <section id="dadOptions" class="choices">
+            <button type="button" class="choice" data-amount="1">$1/day</button>
+            <button type="button" class="choice" data-amount="365">$365/year</button>
+            <label class="custom">Custom Amount
+              <input id="dadAmount" type="number" min="1" step="1" inputmode="decimal" placeholder="$" />
+            </label>
+          </section>
+
+          <section id="dadSummary" class="summary hidden">
+            <p>CONTRIBUTION</p>
+            <p id="contributionAmount" class="amount">$0.00</p>
+            <p id="daysCovered">DAYS COVERED: 0</p>
+            <p id="nextPaymentDate">NEXT PAYMENT DATE: —</p>
+            <button id="resetContribution" class="change" type="button">CHANGE AMOUNT</button>
+          </section>
+
+          <section class="methods">
+            <button id="payCard" class="method" type="button" disabled>PAY BY CARD</button>
+            <button id="payEtransfer" class="method" type="button" disabled>E-TRANSFER</button>
+            <button id="payQR" class="method" type="button" disabled>QR CODE</button>
+          </section>
+
+          <section id="transferInstructions" class="transfer hidden">
+            <p>E-TRANSFER</p>
+            <p>Send to: <strong>ajfisherco@gmail.com</strong></p>
+            <p id="transferAmount">Amount: —</p>
+            <p>Message: DAD Contribution</p>
+          </section>
+
+          <section id="notice" class="notice hidden"><p id="noticeText"></p></section>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    (()=>{
+      const CARD="https://square.link/u/EcyDVlU3?src=site";
+      const QR="https://square.link/u/EcyDVlU3?src=qr";
+      const EMAIL="ajfisherco@gmail.com";
+      const panel=document.querySelector('#panel');
+      const ipm=document.querySelector('#ipmView');
+      const dad=document.querySelector('#dadView');
+      const showButtons=document.querySelectorAll('[data-show]');
+      const dadOptions=document.querySelector('#dadOptions');
+      const dadSummary=document.querySelector('#dadSummary');
+      const dadAmount=document.querySelector('#dadAmount');
+      const contributionAmount=document.querySelector('#contributionAmount');
+      const daysCovered=document.querySelector('#daysCovered');
+      const nextPaymentDate=document.querySelector('#nextPaymentDate');
+      const resetContribution=document.querySelector('#resetContribution');
+      const payCard=document.querySelector('#payCard');
+      const payEtransfer=document.querySelector('#payEtransfer');
+      const payQR=document.querySelector('#payQR');
+      const transferInstructions=document.querySelector('#transferInstructions');
+      const transferAmount=document.querySelector('#transferAmount');
+      const notice=document.querySelector('#notice');
+      const noticeText=document.querySelector('#noticeText');
+      const lockIdea=document.querySelector('#lockIdea');
+      const ideaReceipt=document.querySelector('#ideaReceipt');
+      const assetIdLine=document.querySelector('#assetIdLine');
+      let selected=0;
+
+      function show(which){
+        if(which==='dad'){
+          ipm.classList.add('hidden');
+          dad.classList.remove('hidden');
+          panel.classList.remove('ipm');
+          panel.classList.add('dad');
+        }else{
+          dad.classList.add('hidden');
+          ipm.classList.remove('hidden');
+          panel.classList.remove('dad');
+          panel.classList.add('ipm');
+        }
+      }
+      showButtons.forEach(b=>b.addEventListener('click',()=>show(b.dataset.show)));
+
+      const money=n=>n.toLocaleString('en-CA',{style:'currency',currency:'CAD',minimumFractionDigits:2});
+      const nextDate=d=>{const x=new Date();x.setDate(x.getDate()+Math.max(d,1));return x.toLocaleDateString('en-CA',{month:'long',day:'numeric',year:'numeric'})};
+      const payUrl=(u,a)=>{const x=new URL(u);x.searchParams.set('amount',a);return x.toString()};
+      const active=v=>[payCard,payEtransfer,payQR].forEach(b=>{b.disabled=!v;b.classList.toggle('active',v)});
+
+      function setAmount(v){
+        const n=Number(v);
+        if(!Number.isFinite(n)||n<=0)return;
+        selected=Math.round(n*100)/100;
+        const d=Math.floor(selected);
+        contributionAmount.textContent=money(selected);
+        daysCovered.textContent=`DAYS COVERED: ${d}`;
+        nextPaymentDate.textContent=`NEXT PAYMENT DATE: ${nextDate(d)}`;
+        transferAmount.textContent=`Amount: ${money(selected)}`;
+        dadOptions.classList.add('hidden');
+        dadSummary.classList.remove('hidden');
+        transferInstructions.classList.add('hidden');
+        notice.classList.add('hidden');
+        active(true);
+      }
+
+      dadOptions.addEventListener('click',e=>{
+        const b=e.target.closest('[data-amount]');
+        if(b)setAmount(b.dataset.amount);
+      });
+      dadAmount.addEventListener('input',()=>{if(Number(dadAmount.value)>0)setAmount(dadAmount.value)});
+      resetContribution.addEventListener('click',()=>{
+        selected=0;
+        dadAmount.value='';
+        dadOptions.classList.remove('hidden');
+        dadSummary.classList.add('hidden');
+        transferInstructions.classList.add('hidden');
+        notice.classList.add('hidden');
+        active(false);
+      });
+      payCard.addEventListener('click',()=>{if(selected)window.open(payUrl(CARD,selected),'_blank','noopener,noreferrer')});
+      payQR.addEventListener('click',()=>{if(selected)window.open(payUrl(QR,selected),'_blank','noopener,noreferrer')});
+      payEtransfer.addEventListener('click',async()=>{
+        if(!selected)return;
+        transferInstructions.classList.remove('hidden');
+        noticeText.textContent='E-transfer instructions copied where supported.';
+        notice.classList.remove('hidden');
+        try{await navigator.clipboard.writeText(`DAD Contribution ${money(selected)} to ${EMAIL}`)}catch(e){}
+      });
+
+      lockIdea.addEventListener('click',()=>{
+        const title=document.querySelector('#ideaTitle').value.trim()||'New IPMdb Idea';
+        const from=document.querySelector('#ideaEmail').value.trim();
+        const source=document.querySelector('#ideaSource').value;
+        const desc=document.querySelector('#ideaDescription').value.trim();
+        const now=new Date();
+        const y=now.getFullYear();
+        const m=String(now.getMonth()+1).padStart(2,'0');
+        const d=String(now.getDate()).padStart(2,'0');
+        const id=`IPM-${y}${m}${d}-${Math.floor(100000+Math.random()*900000)}`;
+        assetIdLine.textContent=`ASSET ID: ${id}`;
+        ideaReceipt.classList.remove('hidden');
+        const body=[`ASSET ID: ${id}`,`IDEA TITLE: ${title}`,`EMAIL: ${from}`,`SOURCE: ${source}`,'','DESCRIPTION:',desc].join('\n');
+        window.location.href=`mailto:${EMAIL}?subject=${encodeURIComponent('IPMdb Idea: '+title)}&body=${encodeURIComponent(body)}`;
+      });
+
+      active(false);
+      show('ipm');
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the final DAD payment launch page and activation logic.

## Includes

- `site/dad-payment.html`
- `site/dad-payment.css`
- `site/dad-payment.js`

## Launch rules wired

- `$1/day`
- `$365/year`
- Custom Amount
- Monthly option removed
- Payment methods disabled until a valid amount exists
- Preset options hide after selection
- Days Covered and Next Payment Date calculate from the selected amount
- Active methods: Pay by Card, E-Transfer, QR Code
- Public Complete button removed

## Remaining live values

Replace placeholders in `site/dad-payment.js`:

- `PASTE_SQUARE_CARD_LINK_HERE`
- `PASTE_SQUARE_QR_LINK_HERE`

Interac is set to `ajfisherco@gmail.com`.

## Test path

Deploy these three files with the existing `/site` launch files, then test `dad-payment.html` in browser before launch.
